### PR TITLE
Fix content script injection

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -41,7 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
       chrome.scripting.executeScript(
         {
           target: { tabId: tabId },
-          files: ['content.js']
+          files: ['content.js', 'question_transcript.js']
         },
         () => {
           if (chrome.runtime.lastError) {


### PR DESCRIPTION
## Summary
- ensure popup injects both content.js and question_transcript.js when initializing

## Testing
- `node -e "require('./popup.js')" 2>&1 | head -n 20` *(fails: document undefined as expected)*

------
https://chatgpt.com/codex/tasks/task_e_683f4ba7e6588331aa42df5c2646e22b